### PR TITLE
Ensure all particles are considered in footprint output

### DIFF
--- a/r/src/calc_footprint.r
+++ b/r/src/calc_footprint.r
@@ -44,7 +44,7 @@ calc_footprint <- function(p, output = NULL, r_run_time,
   require(raster)
   require(uataq)
   
-  np <- max(p$indx, na.rm = T)
+  np <- length(unique(p$indx))
   
   # Interpolate particle locations during initial time steps
   times <- c(seq(0, -10, by = -0.1),

--- a/r/src/calc_footprint.r
+++ b/r/src/calc_footprint.r
@@ -170,7 +170,7 @@ calc_footprint <- function(p, output = NULL, r_run_time,
       xyzt_step <- filter(xyzt_layer, time == times[j])
       
       # Create dispersion kernel based using nearest-in-time kernel bandwidth w
-      k <- make_gauss_kernel(xyres, w[kernel$time == times[j]], projection)
+      k <- make_gauss_kernel(xyres, w[find_neighbor(times[j], kernel$time)], projection)
       
       # Array dimensions
       len <- nrow(xyzt_step)

--- a/r/src/calc_footprint.r
+++ b/r/src/calc_footprint.r
@@ -172,11 +172,8 @@ calc_footprint <- function(p, output = NULL, r_run_time,
     for (j in 1:length(times)) {
       xyzt_step <- filter(xyzt_layer, time == times[j])
       
-      # Proceed to next timestep without 2 particles to calculate kernel
-      if (nrow(xyzt_step) < 2) next
-      
-      # Create dispersion kernel based on kernel bandwidth w
-      k <- make_gauss_kernel(xyres, w[kernel$time == times[j]], projection)
+      # Create dispersion kernel based using nearest-in-time kernel bandwidth w
+      k <- make_gauss_kernel(xyres, w[find_neighbor(times[j], kernel$time)], projection)
       
       # Array dimensions
       len <- nrow(xyzt_step)

--- a/r/src/calc_footprint.r
+++ b/r/src/calc_footprint.r
@@ -139,9 +139,6 @@ calc_footprint <- function(p, output = NULL, r_run_time,
     filter(foot > 0, long >= (xmn - xbufh*xres), long < (xmx + xbufh*xres),
            lati >= (ymn - ybufh*yres), lati < (ymx + ybufh*yres))
   if (nrow(xyzt) == 0) return(NULL)
-  mask <- is.element(kernel$time, xyzt$time)
-  kernel <- kernel[mask, ]
-  w <- w[mask]
   
   # Pre grid particle locations
   xyzt <- xyzt %>%
@@ -173,7 +170,7 @@ calc_footprint <- function(p, output = NULL, r_run_time,
       xyzt_step <- filter(xyzt_layer, time == times[j])
       
       # Create dispersion kernel based using nearest-in-time kernel bandwidth w
-      k <- make_gauss_kernel(xyres, w[find_neighbor(times[j], kernel$time)], projection)
+      k <- make_gauss_kernel(xyres, w[kernel$time == times[j]], projection)
       
       # Array dimensions
       len <- nrow(xyzt_step)


### PR DESCRIPTION
Time steps containing only a single particle with foot > 0 were previously skipped as the kernel bandwidth could not be calculated without being able to calculate ensemble dispersion. Especially if these were early time steps, this could reduce the total footprint field. Footprint calculations were restructured in #14 which has made it easier to add these particles back in to improve agreement with idealized footprint fields.