### PR TITLE
Fixes large ensemble size error

### DIFF
--- a/r/src/write_setup.r
+++ b/r/src/write_setup.r
@@ -152,7 +152,7 @@ write_setup <- function(varsiwant, conage = 48, cpack = 1, delt = 0, dxf = 1,
   eq <- function(lhs, rhs) {
     if (is.logical(rhs))
       rhs <- as.numeric(rhs)
-    paste0(lhs, '=', rhs, ',')
+    paste0(lhs, '=', format(rhs, scientific = F), ',')
   }
 
   txt <- c('$SETUP',


### PR DESCRIPTION
Numbers over 100,000 would be formatted with scientific notation ("1e+05"). This ensures numbers are formatted as fortran expects.