### PR TITLE
Optionally specify unique identifier for each simulation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,15 +72,16 @@ str(receptors)
 
 ### Model control
 
-| Arg          | Description                                                                                                                                                                                                                                        |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `n_hours`    | Number of hours to run each simulation; negative indicates backward in time                                                                                                                                                                        |
-| `numpar`     | number of particles to be run; defaults to 200                                                                                                                                                                                                     |
-| `rm_dat`     | Logical indicating whether to delete `PARTICLE.DAT` after each simulation. Default to TRUE to reduce disk space since all of the trajectory information is also stored in `STILT_OUTPUT.rds` alongside the calculated upstream influence footprint |
-| `run_foot`   | Logical indicating whether to produce footprints. If FALSE, `run_trajec` must be TRUE. This can be useful when calculating trajectories separate from footprints                                                                                   |
-| `run_trajec` | Logical indicating whether to produce new trajectories with `hycs_std`. If FALSE, will try to load the previous trajectory outputs. This is often useful for regridding purposes                                                                   |
-| `timeout`    | number of seconds to allow `hycs_std` to complete before sending SIGTERM and moving to the next simulation; defaults to 3600 (1 hour)                                                                                                              |
-| `varsiwant`  | character vector of 4-letter `hycs_std` variables. Defaults to the minimum required variables including `'time', 'indx', 'long', 'lati', 'zagl', 'foot', 'mlht', 'dens', 'samt', 'sigw', 'tlgr'`. Can optionally include options listed below.     |
+| Arg             | Description                                                                                                                                                                                                                                        |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `n_hours`       | Number of hours to run each simulation; negative indicates backward in time                                                                                                                                                                        |
+| `numpar`        | number of particles to be run; defaults to 200                                                                                                                                                                                                     |
+| `rm_dat`        | Logical indicating whether to delete `PARTICLE.DAT` after each simulation. Default to TRUE to reduce disk space since all of the trajectory information is also stored in `STILT_OUTPUT.rds` alongside the calculated upstream influence footprint |
+| `run_foot`      | Logical indicating whether to produce footprints. If FALSE, `run_trajec` must be TRUE. This can be useful when calculating trajectories separate from footprints                                                                                   |
+| `run_trajec`    | Logical indicating whether to produce new trajectories with `hycs_std`. If FALSE, will try to load the previous trajectory outputs. This is often useful for regridding purposes                                                                   |
+| `simulation_id` | Unique identifier for each simulation; defaults to NA which determines a unique identifier for each simulation by hashing the time and receptor location                                                                                           |
+| `timeout`       | number of seconds to allow `hycs_std` to complete before sending SIGTERM and moving to the next simulation; defaults to 3600 (1 hour)                                                                                                              |
+| `varsiwant`     | character vector of 4-letter `hycs_std` variables. Defaults to the minimum required variables including `'time', 'indx', 'long', 'lati', 'zagl', 'foot', 'mlht', 'dens', 'samt', 'sigw', 'tlgr'`. Can optionally include options listed below.     |
 
 #### Optional `varsiwant` arguments
 

--- a/r/run_stilt.r
+++ b/r/run_stilt.r
@@ -57,14 +57,15 @@ met_subgrid_levels <- NA
 n_met_min          <- 1
 
 # Model control
-n_hours    <- -24
-numpar     <- 1000
-rm_dat     <- T
-run_foot   <- T
-run_trajec <- T
-timeout    <- 3600
-varsiwant  <- c('time', 'indx', 'long', 'lati', 'zagl', 'foot', 'mlht', 'dens',
-                'samt', 'sigw', 'tlgr')
+n_hours       <- -24
+numpar        <- 1000
+rm_dat        <- T
+run_foot      <- T
+run_trajec    <- T
+simulation_id <- NA
+timeout       <- 3600
+varsiwant     <- c('time', 'indx', 'long', 'lati', 'zagl', 'foot', 'mlht', 'dens',
+                   'samt', 'sigw', 'tlgr')
 
 # Transport and dispersion settings
 capemin     <- -1
@@ -182,6 +183,7 @@ for (d in c('by-id', 'particles', 'footprints')) {
 
 # Run trajectory simulations ---------------------------------------------------
 stilt_apply(FUN = simulation_step,
+            simulation_id = simulation_id,
             slurm = slurm, 
             slurm_options = slurm_options,
             n_cores = n_cores,

--- a/r/src/simulation_step.r
+++ b/r/src/simulation_step.r
@@ -357,7 +357,7 @@ simulation_step <- function(before_footprint = list(function() {output}),
     # Aggregate the particle trajectory into surface influence footprints. This
     # outputs a .rds file, which can be read with readRDS() containing the
     # resultant footprint and various attributes
-    foot_file <- file.path(rundir, simulation_id, '_foot.nc'))
+    foot_file <- file.path(rundir, paste0(simulation_id, '_foot.nc'))
     foot <- calc_footprint(output$particle, output = foot_file,
                            r_run_time = r_run_time,
                            projection = projection,

--- a/r/src/simulation_step.r
+++ b/r/src/simulation_step.r
@@ -10,6 +10,7 @@
 
 simulation_step <- function(before_footprint = list(function() {output}),
                             before_trajec = list(function() {output}),
+                            simulation_id = NA,
                             capemin = -1,
                             cmass = 0,
                             conage = 48,
@@ -230,20 +231,22 @@ simulation_step <- function(before_footprint = list(function() {output}),
     # Creates subdirectories in out for each model run time. Each of these
     # subdirectories is populated with symbolic links to the shared datasets
     # below and a run-specific SETUP.CFG and CONTROL
-    rundir_format <- paste0('%Y%m%d%H%M_', r_long, '_', r_lati, '_', 
-                            ifelse(length(r_zagl) > 1, 'X', r_zagl))
-    rundir  <- file.path(output_wd, 'by-id',
-                         strftime(r_run_time, rundir_format, 'UTC'))
+    if (is.na(simulation_id)) {
+      simulation_id_format <- paste0('%Y%m%d%H%M_', r_long, '_', r_lati, '_', 
+                                     ifelse(length(r_zagl) > 1, 'X', r_zagl))
+      simulation_id <- strftime(r_run_time, simulation_id_format, 'UTC')
+    }
+    rundir  <- file.path(output_wd, 'by-id', simulation_id)
     dir.create(rundir, showWarnings = F, recursive = T)
     dir.create(file.path(output_wd, 'particles'), showWarnings = F, recursive = T)
     dir.create(file.path(output_wd, 'footprints'), showWarnings = F, recursive = T)
-    message(paste('Running simulation ID:  ', basename(rundir)))
+    message(paste('Running simulation ID:  ', simulation_id))
     
     # Calculate particle trajectories ------------------------------------------
     # run_trajec determines whether to try using existing trajectory files or to
     # recycle existing files
     output <- list()
-    output$file <- file.path(rundir, paste0(basename(rundir), '_traj.rds'))
+    output$file <- file.path(rundir, paste0(simulation_id, '_traj.rds'))
     
     if (run_trajec) {
       # Ensure necessary files and directory structure are established in the
@@ -354,7 +357,7 @@ simulation_step <- function(before_footprint = list(function() {output}),
     # Aggregate the particle trajectory into surface influence footprints. This
     # outputs a .rds file, which can be read with readRDS() containing the
     # resultant footprint and various attributes
-    foot_file <- file.path(rundir, paste0(basename(rundir), '_foot.nc'))
+    foot_file <- file.path(rundir, simulation_id, '_foot.nc'))
     foot <- calc_footprint(output$particle, output = foot_file,
                            r_run_time = r_run_time,
                            projection = projection,

--- a/r/stilt_cli.r
+++ b/r/stilt_cli.r
@@ -132,6 +132,7 @@ stilt_args <- list(
     run_trajec = as.logical(args$run_trajec),
     siguverr = as.numeric(args$siguverr),
     sigzierr = as.numeric(args$sigzierr),
+    simulation_id = as.character(args$simulation_id),
     smooth_factor = as.numeric(args$smooth_factor),
     splitf = as.numeric(args$splitf),
     stilt_wd = as.character(args$stilt_wd),


### PR DESCRIPTION
This allows a `simulation_id` argument to be passed for each receptor to configure the naming of output directories and files. Setting `simulation_id = NA` defaults to the current behavior of generating an identifier by hashing the receptor time and location.