### PR TITLE
Increase default met_subgrid_buffer

### DIFF
--- a/r/run_stilt.r
+++ b/r/run_stilt.r
@@ -51,7 +51,7 @@ yres <- xres
 # Meteorological data input
 met_path           <- '<path_to_arl_meteorological_data>'
 met_file_format    <- '%Y%m%d.%Hz.hrrra'
-met_subgrid_buffer <- 0.1
+met_subgrid_buffer <- 0.2
 met_subgrid_enable <- F
 met_subgrid_levels <- NA
 n_met_min          <- 1


### PR DESCRIPTION
The default of 0.1 can be too small of a buffer for certain meteorological products and can trigger errors in the HYSPLIT fortran code. Increasing the buffer area to 0.2 (20% of the footprint extent) produces successful results more reliably with less user-tweaking.