### PR TITLE
Update find_met_files.r

### DIFF
--- a/r/src/find_met_files.r
+++ b/r/src/find_met_files.r
@@ -29,7 +29,7 @@ find_met_files <- function(t_start, met_file_format, n_hours, met_path) {
     strftime(tz = 'UTC', format = met_file_format)
   
   available <- dir(met_path, full.names = T, recursive = T)
-  available <- available[!grepl('\\.lock$', available)]
+  available <- available[!grepl('.lock', available)]
   
   idx <- do.call(c, lapply(request, function(pattern) {
     grep(pattern = pattern, x = available)


### PR DESCRIPTION
Currently, grepl(...) is set up to exclude file paths with '.lock' at the end; however, the previous line [dir(...)] also lists files within the hrrr.lock directory. These file paths are not removed by the '\\.lock$' pattern in grepl(...), making them appear in the CONTROL files of parallel runs.