### PR TITLE
Fix CI build error during ./setup test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,31 +8,56 @@ on:
     branches:
       - main
 
+env:
+  R_LIBS_USER: .Rpackages
+
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
       - name: Install dependencies
         run: |
           sudo apt-get update -yq
           sudo apt-get install -yq --no-install-recommends \
-            libgfortran3 \
-            libhdf5-serial-dev \
-            libnetcdf-dev \
-            netcdf-bin \
-            unzip
-      - name: Install R
-        uses: r-lib/actions/setup-r@v1
+              build-essential \
+              git \
+              libgdal-dev \
+              libhdf5-serial-dev \
+              libnetcdf-dev \
+              libssl-dev \
+              libxml2-dev \
+              locales \
+              netcdf-bin \
+              procps \
+              r-base \
+              r-base-dev \
+              unzip \
+              wget
+
+      - name: Create R package install path
+        run: mkdir -p $R_LIBS_USER
+
       - name: Install STILT
         run: bash test/test_setup.sh
+
       - name: Run batch simulation test
         run: bash test/test_run_stilt.sh
+
       - name: Run CLI test
         run: bash test/test_stilt_cli.sh
+
       - name: Run CLI column receptor test
         run: bash test/test_stilt_cli.sh
+
       - name: Run WRF test
         run: bash test/test_wrf_converter.sh
+
+      - name: Install Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Test docker build
+        run: docker build -t stilt .

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ exe/xtrct_grid
 exe/xtrct_time
 
 # R history and environment
+.Rpackages
 .RData
 .Rapp.history
 .Rhistory

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,44 +40,37 @@
 #     ymx=40.95 \
 #     yres=0.01
 
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 
 WORKDIR /app
-
-COPY . /app
 
 ENV TZ UTC
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-                build-essential \
-                git \
-                libgdal-dev \
-                libhdf5-serial-dev \
-                libnetcdf-dev \
-                libssl-dev \
-                libxml2-dev \
-                locales \
-                netcdf-bin \
-                procps \
-                r-base \
-                r-base-dev \
-                unzip \
-                wget \
-        && locale-gen en_US.UTF-8 \
-        && update-locale \
-        && bash setup 3 \
-        && Rscript r/dependencies.r \
-        && apt-get remove --purge -y \
-                build-essential \
-                git \
-                locales \
-                wget \
-        && apt-get autoremove -y \
-        && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -yq \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        libgdal-dev \
+        libhdf5-serial-dev \
+        libnetcdf-dev \
+        libssl-dev \
+        libxml2-dev \
+        locales \
+        netcdf-bin \
+        procps \
+        r-base \
+        r-base-dev \
+        unzip \
+        wget \
+    && locale-gen en_US.UTF-8 \
+    && update-locale
+
+COPY . /app
+
+RUN bash setup 3
+RUN Rscript r/dependencies.r
 
 VOLUME ["/app/met", "/app/out"]
 
-ENTRYPOINT ["/app/r/stilt_cli.r", \
-                "met_path=/app/met", \
-                "output_wd=/app/out"]
+ENTRYPOINT ["/app/r/stilt_cli.r", "met_path=/app/met", "output_wd=/app/out"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
                 build-essential \
                 git \
+                libgdal-dev \
                 libhdf5-serial-dev \
                 libnetcdf-dev \
                 libssl-dev \


### PR DESCRIPTION
This fixes the CI error that's currently thrown when testing if `./setup` successfully installs required dependencies.

Appears that some outdated OS dependencies (`libgfortran3`) were removed from upstream package repos so I bumped the dependency versions. Then the `raster` package was having trouble linking to the `libgdal-dev` libs in the CI environment, so I copied some of the more modern OS packages from the [uataq/stiltctl](https://github.com/uataq/stiltctl/blob/main/Dockerfile) framework. Now the build succeeds for the latest (`ubuntu-22.04`) build environment 🥳