### PR TITLE
use default library

### DIFF
--- a/r/run_stilt.r
+++ b/r/run_stilt.r
@@ -7,7 +7,8 @@
 project <- '{{project}}'
 stilt_wd <- file.path('{{wd}}', project)
 output_wd <- file.path(stilt_wd, 'out')
-lib.loc <- .libPaths()[1]
+# lib.loc <- .libPaths()[1]  # Use first library location
+lib.loc <- NULL  # Use default library location
 
 # Parallel simulation settings
 n_cores <- 1


### PR DESCRIPTION
Set `lib.loc <- NULL` to use all libraries. Forcing the user library would install packages into the user library that were already available in the site library. Or if the use library isn't installed, would try to install in the site library which we generally don't have permission for on HPC systems.