### PR TITLE
find_met_files 23hr bug

### DIFF
--- a/r/src/find_met_files.r
+++ b/r/src/find_met_files.r
@@ -31,8 +31,7 @@ find_met_files <- function(t_start, n_hours, met_path,
   met_end <- max(sim_start, sim_end)
   met_end_ceil <- ceiling_date(met_end, unit = met_file_tres)
   if (n_hours < 0 
-      && (hour(met_end) + 1) %% 24 == hour(met_end_ceil)
-      && minute(met_end) > 0) {
+      && (hour(met_end) + 1) %% 24 == hour(met_end_ceil)) {
     # If the end time is at the end of a met file,
     # add an hour to the end time to include the next file.
     # This is necessary to interpolate the last hour of data.

--- a/r/src/find_met_files.r
+++ b/r/src/find_met_files.r
@@ -31,7 +31,7 @@ find_met_files <- function(t_start, n_hours, met_path,
   met_end <- max(sim_start, sim_end)
   met_end_ceil <- ceiling_date(met_end, unit = met_file_tres)
   if (n_hours < 0 
-      && hour(met_end) == hour(met_end_ceil) - 1
+      && (hour(met_end) + 1) %% 24 == hour(met_end_ceil)
       && minute(met_end) > 0) {
     # If the end time is at the end of a met file,
     # add an hour to the end time to include the next file.


### PR DESCRIPTION
When `hour(t_start)` is 23 and `hour(met_end_ceil)` is 24, subtracting by 1 results in negative one. So we need to add to `hour(met_end)` and modulo divide by 24.

Additionally, removed the check for minutes greater than 0. When the time for `t_start` is something like 23:00, some arl files like HRRR can interpolate the last hour, however, other such as the NCAR/NCEP reanalysis and 12km NAM, need the next days file to interpolate the last hour.