### PR TITLE
fix: dedupe met files reachable via multiple paths

### DIFF
--- a/r/src/find_met_files.r
+++ b/r/src/find_met_files.r
@@ -48,6 +48,13 @@ find_met_files <- function(t_start, n_hours, met_path,
   available <- dir(met_path, full.names = T, recursive = T)
   available <- available[!grepl('.lock', available)]
 
+  # Some met archives expose the same file via multiple paths -- e.g. a
+  # top-level symlink pointing into a YYYY/MM/ subdirectory.  recursive=T
+  # finds both the symlink and the real file, and downstream grep yields
+  # duplicate entries that produce a malformed HYSPLIT CONTROL file.
+  # Dedupe by resolved path so each physical file is listed once.
+  available <- available[!duplicated(normalizePath(available, mustWork = FALSE))]
+
   # Find the files that match the request
   idx <- do.call(c, lapply(request, function(pattern) {
     grep(pattern = pattern, x = available)


### PR DESCRIPTION
## Problem
`find_met_files()` uses `dir(met_path, full.names=T, recursive=T)`, which follows symlinks. If a met archive has top-level symlinks pointing into a subdirectory (e.g. `YYYY/MM/`) AND the subdirectory is reachable from the recursive walk, the same physical file is returned twice — once as the top-level symlink path, once as the real path. Both paths then match the `grep` against the requested timestamp, and the duplicates end up in the CONTROL file. `hymodelc` writes "Failed to output PARTICLE_STILT.DAT" with no usable diagnostic.

Hit this on the University of Utah HRRR archive (`/uufs/chpc.utah.edu/common/home/lin-group21/hrrr/hrrr`). 2017 files there are symlinks pointing *outside* the archive root, so `recursive=T` doesn't double-count them. But 2020+ files are organized as `YYYY/MM/<file>` with top-level symlinks pointing *into* those subdirs, so every 2020+ receptor hits the bug.

## Fix
After the existing `dir()` + `.lock` filter, drop duplicates by resolved path:

```r
available <- available[!duplicated(normalizePath(available, mustWork = FALSE))]
