### PR TITLE
fix: bump Docker base image from bullseye to trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,12 +40,12 @@
 #     ymx=40.95 \
 #     yres=0.01
 
-FROM debian:bullseye-slim
+FROM debian:trixie-slim
 
 WORKDIR /app
 
-ENV TZ UTC
-ENV DEBIAN_FRONTEND noninteractive
+ENV TZ=UTC
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yq \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
The Docker build installs R packages from CRAN against the R that the base image ships. debian:bullseye-slim ships R 4.0.4, but current CRAN dplyr (1.2.1) requires R >= 4.1.0, so install.packages() rejects it and `Rscript r/dependencies.r` fails with "load_libs(): Failed to load dplyr".

Bump to debian:trixie-slim (R 4.5.0) so the image's R stays ahead of CRAN's minimum. Also modernize the two ENV lines to key=value form to silence the LegacyKeyValueFormat build warnings.